### PR TITLE
server worker improvement, worker loading crash fix on locahost

### DIFF
--- a/src/app/services/workers/webllm.worker.ts
+++ b/src/app/services/workers/webllm.worker.ts
@@ -1,8 +1,7 @@
 /// <reference lib="webworker" />
-import { MLCEngine, MLCEngineWorkerHandler } from '@mlc-ai/web-llm';
+import { WebWorkerMLCEngineHandler } from '@mlc-ai/web-llm';
 
-const engine = new MLCEngine();
-const handler = new MLCEngineWorkerHandler(engine);
+const handler = new WebWorkerMLCEngineHandler();
 self.onmessage = (msg: MessageEvent) => {
   handler.onmessage(msg);
 };


### PR DESCRIPTION
when "ng server -o" is executed the worker stops and does not work correctly. 

There is an example on github of web-llm where they have changed the way of implementing the worker in a better way

https://github.com/mlc-ai/web-llm/blob/main/examples/simple-chat-ts/src/worker.ts